### PR TITLE
proper single-quoting of cluster nodes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,11 +5,11 @@ rabbitmq_group: "{{ rabbitmq_user }}"
 
 #############
 ## Package
-rabbitmq_version:           '3.6.6-1'
+rabbitmq_version:           '3.7.7-1'
 rabbitmq_signing_key_url:   "https://www.rabbitmq.com/rabbitmq-release-signing-key.asc"
 rabbitmq_deb_pkg:           "rabbitmq-server_{{ rabbitmq_version }}_all.deb"
 rabbitmq_deb_pkg_url: "https://www.rabbitmq.com/releases/rabbitmq-server/v{{ rabbitmq_version.split('-')[0] }}/{{ rabbitmq_deb_pkg }}"
-rabbitmq_yum_repo_baseurl:  "http://www.rabbitmq.com/releases/rabbitmq-server/v{{ rabbitmq_version.split('-')[0] }}"
+rabbitmq_yum_repo_baseurl:  "https://github.com/rabbitmq/rabbitmq-server/releases/download/v{{ rabbitmq_version.split('-')[0] }}"
 
 
 #################

--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -13,7 +13,7 @@
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
 {% endif %}
 {% if rabbitmq_config_cluster %}
-    {cluster_nodes, {[rabbit@{{ rabbitmq_cluster_nodes|join(', rabbit@') }}], {{ rabbitmq_cluster_node_type -}} }},
+    {cluster_nodes, {['rabbit@{{ rabbitmq_cluster_nodes|join("', 'rabbit@") }}'], {{ rabbitmq_cluster_node_type -}} }},
     {cluster_partition_handling, {{ rabbitmq_cluster_partition_handling -}} },
 {% endif %}
     {tcp_listen_options,


### PR DESCRIPTION
Server won't launch with unquoted node names, and trying to add them at the parameter level just gets you `rabbit@'hostname'` because the rabbit append is explicitly before the parameter